### PR TITLE
Order versions list from minor to mayor version.

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -203,10 +203,10 @@ versions_list=(
 )
 
 versions=""
+sorted_versions=($(printf '%s\n' "${versions_list[@]}"|sort))
 
 # Concatenate all the versions together separated by spaces
-for version in "${versions_list[@]}"
-do
+for version in "${sorted_versions[@]}";  do
       versions="${versions} ${version}"
 done
 


### PR DESCRIPTION
Order versions list from minor to mayor version according to the pseudo-standard used in other asdf plugins.

Also, now the versions are sorted, so you can add a new one in any place of the array and it would appear in it's correct position.